### PR TITLE
Corrected Misspelling: "CEnter" to "Enter"

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -199,7 +199,7 @@
 <a href="#d3-preview" class="anchor"></a>D3 Preview</h2>
 <p>The <a href="https://www.rstudio.com/rstudio/download/preview/">RStudio v1.2 preview release</a> of RStudio includes support for previewing D3 scripts as you write them. To try this out, create a D3 script using the new file menu:</p>
 <p><img src="tools/README/new_script.png" class="screenshot" width="600/"></p>
-<p>A simple template for a D3 script (the barchart.js example shown above) is provided by default. You can use the <strong>Preview</strong> command (Ctrl+Shift+Center) to render the visualization:</p>
+<p>A simple template for a D3 script (the barchart.js example shown above) is provided by default. You can use the <strong>Preview</strong> command (Ctrl+Shift+Enter) to render the visualization:</p>
 <p><img src="tools/README/rstudio_preview.png" class="screenshot" width="600/"></p>
 <p>You might wonder where the data comes from for the preview. Note that there is a special comment at the top of the D3 script:</p>
 <div class="sourceCode" id="cb4"><pre class="sourceCode js"><code class="sourceCode javascript"><a class="sourceLine" id="cb4-1" title="1"><span class="co">// !preview r2d3 data=c(0.3, 0.6, 0.8, 0.95, 0.40, 0.20)</span></a></code></pre></div>


### PR DESCRIPTION
Propose correcting  Misspelled: "CEnter" to "Enter"
Cheers,
Mike